### PR TITLE
Update @updatedAt and now() warning messages to clarify problem only exists in versions before 4.4.0

### DIFF
--- a/content/200-orm/500-reference/100-prisma-schema-reference.mdx
+++ b/content/200-orm/500-reference/100-prisma-schema-reference.mdx
@@ -2783,7 +2783,7 @@ Automatically stores the time when a record was last updated. If you do not supp
 
 :::warning
 
-If you're also using [`now()`](/orm/reference/prisma-schema-reference#now), the time might differ from the `@updatedAt` values if your database and app have different timezones. This happens because `@updatedAt` operates at the Prisma ORM level, while `now()` operates at the database level.
+In versions before [4.4.0](https://github.com/prisma/prisma/releases/tag/4.4.0) if you're also using [`now()`](/orm/reference/prisma-schema-reference#now), the time might differ from the `@updatedAt` values if your database and app have different timezones. This happens because `@updatedAt` operates at the Prisma ORM level, while `now()` operates at the database level.
 
 :::
 
@@ -3320,7 +3320,7 @@ Set a timestamp of the time when a record is created.
 
 :::warning
 
-If you're also using [`@updatedAt`](/orm/reference/prisma-schema-reference#updatedat), the time might differ from the `now()` values if your database and app have different timezones. This happens because `@updatedAt` operates at the Prisma ORM level, while `now()` operates at the database level.
+In versions before [4.4.0](https://github.com/prisma/prisma/releases/tag/4.4.0) if you're also using [`@updatedAt`](/orm/reference/prisma-schema-reference#updatedat), the time might differ from the `now()` values if your database and app have different timezones. This happens because `@updatedAt` operates at the Prisma ORM level, while `now()` operates at the database level.
 
 :::
 


### PR DESCRIPTION
## Description
This PR updates the prisma-schema-reference documentation "warnings" for the [`@updatedAt`](https://www.prisma.io/docs/orm/reference/prisma-schema-reference#updatedat) and [`now()`](https://www.prisma.io/docs/orm/reference/prisma-schema-reference#now) attributes to clarify that the problem of the attributes producing different times only exists for versions before 4.4.0

## Background
The [Prisma ORM v4.4.0 release](https://github.com/prisma/prisma/releases/tag/4.4.0) fixed [prisma/prisma Issue #12572](https://github.com/prisma/prisma/issues/12572) with the updates from [prisma/prisma-engines PR #3200](https://github.com/prisma/prisma-engines/pull/3200). So, for Prisma versions v4.4.0 or later, the warnings about `@updatedAt` and `now()` producing different times do not apply.

## Related Issues
This PR will resolve [prisma/docs Issue #6825](https://github.com/prisma/docs/issues/6825)